### PR TITLE
Bug fix/pulldown search

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -29,12 +29,17 @@ describe('Find My Mtb', () => {
   it('Should have an about section', () => {
     cy.get('.about-card').contains('We\'re all about helping you find the perfect bike to fit your needs. Whether you\'re new to the sport or a seasoned pro, you\'ve come to the right place!')
   })
-  it('Should be able to select criteria and filter through bikes to display', () => {
+  it('Should be able to select criteria and filter through bikes to display, and see details about that bike.', () => {
     cy.get('h1').contains('Find The Perfect Bike For You!')
     cy.get('#skillLevel').select('Advanced')
-    cy.get('.bikes-display').find('.bike-card').should('have.length', 3)
+    cy.get('#terrain').select('Rocky and Chunky')
+    cy.get('.submit-search').click()
+    cy.get('.bikes-display').find('.bike-card').should('have.length', 1)
+    cy.get('.bike-card').first().contains('Nomad').click()
+    cy.get('.bike-detail').contains('Santa Cruz')
+    cy.get('.close-button').click()
+    cy.get('.bikes-display').find('.bike-card').should('have.length', 1)
     cy.get('.bike-card').first().contains('Nomad')
-    cy.get('.bike-card').last().contains('Ibis')
   })
   it('Should navigate to the all bikes page and display all bikes', () => {
     cy.get('.link').contains('All Bikes').click()

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,6 +1,5 @@
 describe('Find My Mtb', () => {
   beforeEach(() => {
-    cy.visit('http://localhost:3000');
     cy.intercept('GET', 'http://localhost:3001/api/v1/bikes', {
       statusCode: 200,
       fixture: 'mockdata.json'
@@ -13,6 +12,7 @@ describe('Find My Mtb', () => {
       statusCode: 200,
       fixture: 'singleBike.json'
     })
+    cy.visit('http://localhost:3000');
   });
   it('Successfully Loads', () => {
     cy.visit('http://localhost:3000');

--- a/src/Components/MainPage/MainPage.css
+++ b/src/Components/MainPage/MainPage.css
@@ -16,6 +16,9 @@
 
 .search-form {
     width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 select {

--- a/src/Components/MainPage/MainPage.jsx
+++ b/src/Components/MainPage/MainPage.jsx
@@ -12,17 +12,14 @@ export default function Main({ allBikes, error }) {
         skillLevel: "",
         terrain: ""
     })
-    // const [terrain, setTerrain] = useState("")
-   console.log('skill', pullDownData.skillLevel)
-   console.log('terrain', pullDownData.terrain)
+
    function filterBikes(name, value) {
     const bikesByFilter = allBikes.filter(bike => {
-        console.log(bike[name], 'here')
         return (bike[name].includes(value))
     })
-    console.log(bikesByFilter, 'filteredBikes')
-    // return bikesByFilter
-    setFilteredBikes(bikesByFilter)
+    return bikesByFilter
+    // console.log(bikesByFilter, 'filteredBikes')
+    // setFilteredBikes(bikesByFilter)
    }
 
    function handleChange(e) {
@@ -46,7 +43,7 @@ if (error) {
     return (
         <div className="main-page">
             <h1>Find The Perfect Bike For You!</h1>
-            <form className="search-form" onSubmit={handleSubmit}>
+            <form className="search-form">
                 <select
                 id="skillLevel"
                 value={pullDownData.skillLevel}
@@ -72,6 +69,12 @@ if (error) {
                     <option value="Race">XC Race Course</option>
                     <option value="Park">Bike Park</option>
                 </select>
+                <Link>
+                <box-icon name='refresh' size='lg' color='#0662a0'></box-icon>
+                </Link>
+                <Link onSubmit={handleSubmit}>
+                <box-icon name='send' size='md' color='#0662a0'></box-icon>
+                </Link>
             </form>
             <div>
                 {filteredBikes.length === 0 ? <About className="filtered-bikes-display"/> : <BikesDisplay allBikes={filteredBikes} />} 

--- a/src/Components/MainPage/MainPage.jsx
+++ b/src/Components/MainPage/MainPage.jsx
@@ -12,30 +12,63 @@ export default function Main({ allBikes, error }) {
         skillLevel: "",
         terrain: ""
     })
-
-   function filterBikes(name, value) {
-    const bikesByFilter = allBikes.filter(bike => {
-        return (bike[name].includes(value))
-    })
-    return bikesByFilter
-    // console.log(bikesByFilter, 'filteredBikes')
-    // setFilteredBikes(bikesByFilter)
-   }
-
-   function handleChange(e) {
-    const selectedValue = e.target.value
-    const selectedName = e.target.name
-    setPullDownData((prevData) => {
-        return {...prevData,
-            [selectedName]: selectedValue
+    // console.log('pullme', pullDownData)
+    useEffect(() => {
+        const savedPullDownData = localStorage.getItem('pullDownData');
+        if (savedPullDownData) {
+            // console.log((savedPullDownData, 'pulldata<><><><><><'))
+            const parsedData = JSON.parse(savedPullDownData);
+            console.log(parsedData, 'parsed<><><><><><><><><')
+            setPullDownData(parsedData);
+            filterBikes(parsedData, allBikes); // Filter bikes with the saved data
+        } else {
+            setFilteredBikes([]); // No filter applied initially
         }
-   })
-   filterBikes(selectedName, selectedValue)
-}
+    }, [allBikes]);
 
-function handleSubmit(e) {
-    e.preventDefault();
-}
+    // useEffect(() => {
+    //     localStorage.setItem('pullDownData', JSON.stringify(pullDownData));
+    //     filterBikes(pullDownData, allBikes);
+    //     console.log('pull form set local', pullDownData)
+    // }, [pullDownData]);
+
+    function filterBikes(data, bikes) {
+        let filtered = bikes;
+        if (data.skillLevel) {
+            filtered = filtered.filter(bike => bike.skillLevel.includes(data.skillLevel));
+        }
+        if (data.terrain) {
+            filtered = filtered.filter(bike => bike.terrain.includes(data.terrain));
+        }
+        setFilteredBikes(filtered);
+        // console.log("🚀 ~ in filterBikes ~ filteredBikes:", filteredBikes)
+    };
+
+    function handleChange(e) {
+        const { name, value } = e.target;
+        setPullDownData(prevData => ({
+            ...prevData,
+            [name]: value
+        }));
+    };
+
+    function handleSubmit(e) {
+        e.preventDefault();
+        // console.log('here')
+        localStorage.setItem('pullDownData', JSON.stringify(pullDownData));
+        filterBikes(pullDownData, allBikes);
+    };
+
+    function resetSearch() {
+        setPullDownData({
+            skillLevel: "",
+            terrain: ""
+        })
+        localStorage.setItem('pullDownData', JSON.stringify(pullDownData))
+        setFilteredBikes([])
+    }
+
+
 
 if (error) {
     return <div className="all-bikes-error">{`There was a problem loading the site, please try again later ${error}`}</div>
@@ -69,10 +102,10 @@ if (error) {
                     <option value="Race">XC Race Course</option>
                     <option value="Park">Bike Park</option>
                 </select>
-                <Link>
+                <Link onClick={resetSearch}>
                 <box-icon name='refresh' size='lg' color='#0662a0'></box-icon>
                 </Link>
-                <Link onSubmit={handleSubmit}>
+                <Link onClick={handleSubmit}>
                 <box-icon name='send' size='md' color='#0662a0'></box-icon>
                 </Link>
             </form>

--- a/src/Components/MainPage/MainPage.jsx
+++ b/src/Components/MainPage/MainPage.jsx
@@ -102,10 +102,10 @@ if (error) {
                     <option value="Race">XC Race Course</option>
                     <option value="Park">Bike Park</option>
                 </select>
-                <Link onClick={resetSearch}>
+                <Link onClick={resetSearch} className="refresh-search">
                 <box-icon name='refresh' size='lg' color='#0662a0'></box-icon>
                 </Link>
-                <Link onClick={handleSubmit}>
+                <Link onClick={handleSubmit} className="submit-search">
                 <box-icon name='send' size='md' color='#0662a0'></box-icon>
                 </Link>
             </form>


### PR DESCRIPTION
# Pull Request
## Description
Bug fix for search criteria resetting after closing the bike detail dialogue box.
## Related Issues
Closes #8 
## Changes Made
Before this branch/PR, when a user entered search criteria and received a list of bikes, clicking on a bike to view its details and then closing the detail view would reset the form data. This resulted in the search criteria being lost, and the main page photo being displayed instead of the filtered bike list.
## Testing
Local testing was done to ensure the expected outcome when closing out of a bike detail view. The data now persists on page change and reload. The form will only be reset if the user chooses to reset it. Cypress testing was also updated to ensure the path and user flow is working properly. 
## Checklist
- [x] The code follows the project's coding standards.
- [x] E2E tests have been added or updated to cover the changes.
- [x] The code compiles without errors.
- [x] The changes have been tested locally and pass all relevant tests.
- [x] All new and existing tests pass.
## Additional Information
To achieve the goal of having the form data persist on page changes and refresh, I utilized local storage. 
