### PR TITLE
Fix formData persisting on refresh button

### DIFF
--- a/src/Components/MainPage/MainPage.jsx
+++ b/src/Components/MainPage/MainPage.jsx
@@ -64,7 +64,7 @@ export default function Main({ allBikes, error }) {
             skillLevel: "",
             terrain: ""
         })
-        localStorage.setItem('pullDownData', JSON.stringify(pullDownData))
+        localStorage.clear()
         setFilteredBikes([])
     }
 


### PR DESCRIPTION

# Pull Request
## Description
Form data was persisting when the reset/refresh button was clicked.
## Related Issues
Closes #16 
## Changes Made
Prior to this PR, the local storage was not being reset properly when a user clicked the refresh/reset button for the pulldown form input on the main page. 
## Testing
Local testing was done to ensure the form reset/refresh button is working as intended and the data is not persisting after it is clicked. 
## Checklist
- [x] The code follows the project's coding standards.
- [x] The code compiles without errors.
- [x] The changes have been tested locally and pass all relevant tests.
- [x] All new and existing tests pass.