### PR TITLE
change cover image to https for vercel

### DIFF
--- a/src/Components/About/About.css
+++ b/src/Components/About/About.css
@@ -3,7 +3,7 @@
   height: 600px;
   display: flex;
   justify-content: center;
-  background-image: url("http://localhost:3000/Westridge1.jpg");
+  background-image: url("https://localhost:3000/Westridge1.jpg");
   background-size: cover;
   background-position: top;
   border-radius: 8px;


### PR DESCRIPTION
Cover image was using http instead of https and I was getting the following error, so I changed to https:

find-my-mtb.vercel.app/:1 Mixed Content: The page at 'https://find-my-mtb.vercel.app/' was loaded over HTTPS, but requested an insecure element 'http://localhost:3000/Westridge1.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.html