### PR TITLE
refactor cypress testing to work with Vercel api calls

### DIFF
--- a/cypress/e2e/allBikeErrorHandling.cy.js
+++ b/cypress/e2e/allBikeErrorHandling.cy.js
@@ -1,10 +1,10 @@
 describe('All Bikes Error Handling', () => {
     beforeEach(() => {
-      cy.visit('http://localhost:3000');
-      cy.intercept('GET', 'http://localhost:3001/api/v1/bikes', {
+      cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes', {
         statusCode: 500 });
-      cy.intercept('GET', 'http://localhost:3001/api/v1/bikes/1', {
+      cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/1', {
         statusCode: 404 });
+      cy.visit('https://find-my-mtb.vercel.app/');
     });
     it('Should show an error message when there no bikes are fetched from the server', () => {
       cy.get('.link').contains('All Bikes').click()

--- a/cypress/e2e/singleBikeErrorHandling.cy.js
+++ b/cypress/e2e/singleBikeErrorHandling.cy.js
@@ -1,13 +1,13 @@
 describe('Single Bike Error Handling', () => {
     beforeEach(() => {
-      cy.visit('http://localhost:3000');
-      cy.intercept('GET', 'http://localhost:3001/api/v1/bikes', {
+      cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes', {
         statusCode: 200,
         fixture: 'mockdata.json'
       });
-      cy.intercept('GET', 'http://localhost:3001/api/v1/bikes/1', {
+      cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/1', {
         statusCode: 404
       });
+      cy.visit('https://find-my-mtb.vercel.app/');
     })
     it('Should show an error when a bike cannot be found', () => {
         cy.get('.link').contains('All Bikes').click()

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,25 +1,25 @@
 describe('Find My Mtb', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:3001/api/v1/bikes', {
+    cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes', {
       statusCode: 200,
       fixture: 'mockdata.json'
     });
-    cy.intercept('GET', 'http://localhost:3001/api/v1/bikes/1', {
+    cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/1', {
       statusCode: 200,
       fixture: 'singleBike.json'
     });
-    cy.intercept('GET', 'http://localhost:3001/api/v1/bikes/3', {
+    cy.intercept('GET', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/3', {
       statusCode: 200,
       fixture: 'singleBike2.json'
     });
-    cy.intercept('PATCH', 'http://localhost:3001/api/v1/bikes/3', {
+    cy.intercept('PATCH', 'https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/3', {
       statusCode: 200,
       fixture: 'singleBike2.json'
     })
-    cy.visit('http://localhost:3000');
+    cy.visit('https://find-my-mtb.vercel.app/');
   });
   it('Successfully Loads', () => {
-    cy.visit('http://localhost:3000');
+    cy.visit('https://find-my-mtb.vercel.app/');
   });
   it('Should have a page title and navigation links', () => {
     cy.get('.header').contains('Find My Mtb');
@@ -47,7 +47,9 @@ describe('Find My Mtb', () => {
   })
   it('Should navigate to the all bikes page and display all bikes', () => {
     cy.get('.link').contains('All Bikes').click()
-    cy.get('.bikes-display').find('.bike-card').should('have.length', 5)
+    cy.wait(2000)
+    cy.get('.bike-card').its('length')
+    cy.get('.bikes-display').find('.link .bike-card').should('have.length', 5)
     cy.get('.bike-card').first().contains('Hightower')
     cy.get('.bike-card').last().contains('Exie')
   })

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,7 +1,6 @@
 export async function fetchBikes() {
   try {
-    // const response = await fetch("http://localhost:3001/api/v1/bikes"); for local testing
-    const response = await fetch("https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes"); //for vercel deployment
+    const response = await fetch("https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes"); 
     if (!response.ok) {
       throw new Error("There is an issue getting the bikes");
     }
@@ -14,8 +13,7 @@ export async function fetchBikes() {
 
 export async function fetchSingleBike(id) {
   try {
-    // const response = await fetch(`http://localhost:3001/api/v1/bikes/${id}`); for local testing
-    const response = await fetch(`https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/${id}`); // for vercel deployment
+    const response = await fetch(`https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/${id}`); 
     if (!response.ok) {
       throw new Error("The bike you requested could not be found");
     }
@@ -29,10 +27,6 @@ export async function fetchSingleBike(id) {
 
 export async function updateFavorite(id) {
   try {
-    // const response = await fetch(`https://localhost:3001/api/v1/bikes/${id}`, {
-    //   method: "PATCH",
-    //   headers: { "Content-Type": "application/json" },
-    // }); for local testing
     const response = await fetch(`https://find-my-mtb-9n78cpo73-brandon-dozas-projects.vercel.app/api/v1/bikes/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -47,7 +41,6 @@ export async function updateFavorite(id) {
     throw error;
   }
 }
-
 
 //For Future Use To Add Bike
 // export async function postBike(dataToPost) {


### PR DESCRIPTION
Cypress tests were refactored to use the new url generated by Vercel. All tests are passing. 